### PR TITLE
Delete the deprecated --input_format option in quick_start.rst test scripts 

### DIFF
--- a/docs/source/getting_started/quick_start.rst
+++ b/docs/source/getting_started/quick_start.rst
@@ -62,8 +62,7 @@ Let's annotate Carbohydrate-Active enZYmes (CAZymes) in our example data.
       --input_raw_data EscheriaColiK12MG1655.faa \
       --mode protein \
       --output_dir output_EscheriaColiK12MG1655_faa \
-      --db_dir db \
-      --input_format NCBI
+      --db_dir db 
 
 **Example 3: Eukaryotic Proteome (NCBI)**
 
@@ -148,7 +147,6 @@ Next, let's identify and analyze CAZyme gene clusters (CGCs).
       --mode protein \
       --output_dir output_EscheriaColiK12MG1655_faa_CGC \
       --db_dir db \
-      --input_format NCBI \
       --input_gff EscheriaColiK12MG1655.gff \
       --gff_type NCBI_prok
 
@@ -165,7 +163,6 @@ Next, let's identify and analyze CAZyme gene clusters (CGCs).
       --mode protein \
       --output_dir output_Xylona_heveae_TC161_faa_CGC \
       --db_dir db \
-      --input_format NCBI \
       --input_gff Xylona_heveae_TC161.gff \
       --gff_type NCBI_euk
 
@@ -182,7 +179,6 @@ Next, let's identify and analyze CAZyme gene clusters (CGCs).
       --mode protein \
       --output_dir output_Xylhe1_faa_CGC \
       --db_dir db \
-      --input_format JGI \
       --input_gff Xylhe1_GeneCatalog_proteins_20130827.gff \
       --gff_type JGI
 
@@ -240,7 +236,6 @@ Finally, let's predict substrates for the identified CAZymes and CGCs.
       --mode protein \
       --output_dir output_EscheriaColiK12MG1655_faa_sub \
       --db_dir db \
-      --input_format NCBI \
       --input_gff EscheriaColiK12MG1655.gff \
       --gff_type NCBI_prok
 
@@ -254,7 +249,6 @@ Finally, let's predict substrates for the identified CAZymes and CGCs.
       --mode protein \
       --output_dir output_Xylona_heveae_TC161_faa_sub \
       --db_dir db \
-      --input_format NCBI \
       --input_gff Xylona_heveae_TC161.gff \
       --gff_type NCBI_euk
 
@@ -268,7 +262,6 @@ Finally, let's predict substrates for the identified CAZymes and CGCs.
       --mode protein \
       --output_dir output_Xylhe1_faa_sub \
       --db_dir db \
-      --input_format JGI \
       --input_gff Xylhe1_GeneCatalog_proteins_20130827.gff \
       --gff_type JGI
 


### PR DESCRIPTION
Apparently the option --input_format is no longer an option to the commands  : 
- run_dbcan CAZyme_annotation
- run_dbcan easy_substrate
- run_dbcan easy_CGC When using it the following error appears : 
No such option: --input_format Did you mean --input_raw_data?  But when removed everything works fine