### PR TITLE
Default --threads to the affinity-constrained CPU count

### DIFF
--- a/dbcan/parameter.py
+++ b/dbcan/parameter.py
@@ -33,10 +33,26 @@ output_dir_option = click.option(
     type=click.Path(file_okay=False, dir_okay=True),
     help='Output directory (created if needed). All run_dbcan result files are written here.',
 )
+def _default_threads() -> int:
+    """Default worker count, constrained to the CPUs the process may use.
+
+    ``psutil.cpu_count()`` reports every logical core on the host and ignores
+    the CPU-affinity mask the process runs under (SLURM cgroup, ``taskset``,
+    container limits). On a shared HPC node that makes the ``--threads``
+    default far larger than the allocation, oversubscribing DIAMOND badly
+    enough to trigger SIGBUS, multi-hour hangs, or node failures. Prefer the
+    affinity-constrained count where the platform exposes it.
+    """
+    try:
+        return len(psutil.Process().cpu_affinity()) or 1
+    except (AttributeError, NotImplementedError, OSError):
+        return psutil.cpu_count() or 1
+
+
 threads_option = click.option(
     '--threads',
     type=int,
-    default=psutil.cpu_count() or 1,
+    default=_default_threads(),
     show_default=True,
     help='Parallel worker count for supported tools (DIAMOND, pyhmmer CPU threads, etc.).',
 )


### PR DESCRIPTION
## Problem

`--threads` defaults to `psutil.cpu_count()` (`dbcan/parameter.py`, `threads_option`), which reports the host's total logical cores and ignores the CPU-affinity mask the process runs under (SLURM cgroup, `taskset`, container limits).

On a constrained allocation — e.g. 6 CPUs on a 256-core HPC node — omitting `--threads` makes DIAMOND run with `--threads 256`, a ~42× oversubscription that crashes it with `SIGBUS`, hangs it for hours, or destabilises the node.

Full report and reproduction: #73

## Change

Add a `_default_threads()` helper and use it as the `--threads` default:

- uses `psutil.Process().cpu_affinity()` — affinity-aware, so it respects SLURM cgroups / `taskset` / container CPU limits;
- falls back to `psutil.cpu_count()` on platforms that don't expose CPU affinity (e.g. macOS);
- no new imports — `psutil` is already used in this module.

No behavioural change on an unconstrained host; on a constrained allocation the default now matches the CPUs actually granted to the process.

## Notes

Opened as a draft for maintainer review — I haven't run the test suite locally. See #73 for a secondary point worth checking: whether an explicit `--threads N` fully propagates into the per-step `DiamondTCConfig` / `DiamondTFConfig` for `easy_substrate` / `easy_CGC`.

Addresses #73
